### PR TITLE
Containerize go-libp2p-relay-daemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Container
+
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+  pull_request: { }
+
+jobs:
+  builder:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: "libp2p-relay-daemon:${{ github.sha }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build Container Image
+        env:
+          DOCKER_BUILDKIT: '1'
+        run: docker build -t "${IMAGE_TAG}" .
+      - name: Check Container Image
+        run: docker run "${IMAGE_TAG}" --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.19-bullseye as BUILD
+
+ARG GO_LIBP2P_RELAY_DAEMON_VERSION="0.3.0"
+ENV CGO_ENABLED=0
+RUN go install github.com/libp2p/go-libp2p-relay-daemon/cmd/libp2p-relay-daemon@v${GO_LIBP2P_RELAY_DAEMON_VERSION}
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=BUILD /go/bin/libp2p-relay-daemon /usr/bin/
+
+ENTRYPOINT ["/usr/bin/libp2p-relay-daemon"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# libp2p-relay
-Cloud Native libp2p Relay Daemon
+# libp2p-relay-daemon
+
+This repository provides a Cloud Native ready to deploy libp2p relay daemon, including:
+
+* Containerised [`go-libp2p-relay-daemon`](https://github.com/libp2p/go-libp2p-relay-daemon)
+* Kubernetes manifests to run the daemon as a deployment object
+
+Additionally, it provides:
+
+* Example deployment manifest to run the daemon with stable libp2p identity
+* Development utilities to run the daemon on a local Kubernetes cluster


### PR DESCRIPTION
Create a minimal container from go-libp2p-relay-daemon and add a CI job to check it is built correctly and runs.